### PR TITLE
feat(auth): Add forgot/reset password functionality for users

### DIFF
--- a/src/modules/user/user.crud.ts
+++ b/src/modules/user/user.crud.ts
@@ -187,6 +187,44 @@ export class UserCrud {
     } as IUser;
   }
 
+  async setPasswordResetToken(
+    email: string,
+    token: string,
+    expiry: Date
+  ): Promise<IUser | null> {
+    const user = await UserSchema.findOneAndUpdate(
+      { email },
+      {
+        $set: {
+          passwordResetToken: token,
+          passwordResetExpiry: expiry
+        }
+      },
+      { new: true }
+    );
+    return user ? this.toUserResponse(user) : null;
+  }
+
+  async updatePassword(
+    userId: string,
+    hashedPassword: string
+  ): Promise<IUser | null> {
+    if (!mongoose.Types.ObjectId.isValid(userId)) return null;
+
+    const user = await UserSchema.findByIdAndUpdate(
+      userId,
+      {
+        $set: {
+          password: hashedPassword,
+          passwordResetToken: null,
+          passwordResetExpiry: null
+        }
+      },
+      { new: true }
+    );
+    return user ? this.toUserResponse(user) : null;
+  }
+
   public toUser(userDoc: IUserDocument): IUser {
     return {
       ...userDoc.toObject(),

--- a/src/modules/user/user.router.ts
+++ b/src/modules/user/user.router.ts
@@ -9,6 +9,8 @@ const userController = new UserController();
 router.post('/register', userController.register.bind(userController));
 router.post('/verify-email', userController.verifyEmail.bind(userController));
 router.post('/login', userController.login.bind(userController));
+router.post('/forgot-password', userController.forgotPassword.bind(userController));
+router.post('/reset-password', userController.resetPassword.bind(userController));
 
 // Protected routes (require authentication)
 router.use(authMiddleware);


### PR DESCRIPTION
- Add forgot password and reset password endpoints for users
- Implement password reset token generation and validation
- Add email notification for password reset requests
- Mirror existing consumer password reset implementation

New endpoints:
- POST /api/users/forgot-password
- POST /api/users/reset-password

Technical changes:
- Add setPasswordResetToken and updatePassword methods to UserCrud
- Add forgotPassword and resetPassword controllers
- Update user router with new public routes
- Integrate with existing OTP and email helpers

Security:
- Token expiration handling
- Password hashing
- Token validation before reset